### PR TITLE
[Docs] #18 added version indicator for doc-website

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -23,6 +23,8 @@
         "assets": [
           "package.json",
           "package-lock.json",
+          "docs/package.json",
+          "docs/package-lock.json",
           "CHANGELOG.md"
         ],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"

--- a/docs/.vitepress/cache/deps/_metadata.json
+++ b/docs/.vitepress/cache/deps/_metadata.json
@@ -1,49 +1,49 @@
 {
-  "hash": "09da0a02",
+  "hash": "334951a4",
   "configHash": "c1e2a9ff",
-  "lockfileHash": "cca6cc97",
-  "browserHash": "da177740",
+  "lockfileHash": "706478d1",
+  "browserHash": "3b657482",
   "optimized": {
     "vue": {
       "src": "../../../node_modules/vue/dist/vue.runtime.esm-bundler.js",
       "file": "vue.js",
-      "fileHash": "26b39272",
+      "fileHash": "72a6db04",
       "needsInterop": false
     },
     "vitepress > @vue/devtools-api": {
       "src": "../../../node_modules/@vue/devtools-api/dist/index.js",
       "file": "vitepress___@vue_devtools-api.js",
-      "fileHash": "14a05e67",
+      "fileHash": "135233f4",
       "needsInterop": false
     },
     "vitepress > @vueuse/core": {
       "src": "../../../node_modules/@vueuse/core/index.mjs",
       "file": "vitepress___@vueuse_core.js",
-      "fileHash": "7a50a48d",
+      "fileHash": "32c1322b",
       "needsInterop": false
     },
     "vitepress > @vueuse/integrations/useFocusTrap": {
       "src": "../../../node_modules/@vueuse/integrations/useFocusTrap.mjs",
       "file": "vitepress___@vueuse_integrations_useFocusTrap.js",
-      "fileHash": "a384743f",
+      "fileHash": "aeebf412",
       "needsInterop": false
     },
     "vitepress > mark.js/src/vanilla.js": {
       "src": "../../../node_modules/mark.js/src/vanilla.js",
       "file": "vitepress___mark__js_src_vanilla__js.js",
-      "fileHash": "a2345b94",
+      "fileHash": "89b87b45",
       "needsInterop": false
     },
     "vitepress > minisearch": {
       "src": "../../../node_modules/minisearch/dist/es/index.js",
       "file": "vitepress___minisearch.js",
-      "fileHash": "1eb9588f",
+      "fileHash": "c5bd68fe",
       "needsInterop": false
     },
     "@theme/index": {
       "src": "../../../node_modules/vitepress/dist/client/theme-default/index.js",
       "file": "@theme_index.js",
-      "fileHash": "ed317aad",
+      "fileHash": "93dc045a",
       "needsInterop": false
     }
   },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitepress"
+import pkg from "../package.json"
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -26,8 +27,20 @@ export default defineConfig({
     nav: [
       { text: "Guide", link: "/guide" },
       { text: "Reference", link: "/api" },
-      { text: "Our Team", link: "/team" }
-
+      { text: "Our Team", link: "/team" },
+      {
+        text: `v${pkg.version}`,
+        items: [
+          {
+            text: "Releases",
+            link: "https://github.com/mahabubx7/akar/releases"
+          },
+          {
+            text: "New Issue",
+            link: "https://github.com/mahabubx7/akar/issues/new/choose"
+          }
+        ]
+      }
       // sponsers place
     ],
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "description": "akar.js documentation website using vitepress",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "release": "release-it",
     "format": "prettier --write .",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
### [Docs] #18 added version indicator for doc-website
- [x] Fixes docs/package.json version including `semantic-release` config.
- [x] Navbar shows the version as expected ✅ 